### PR TITLE
Add `deserialize_vec_from_string` function

### DIFF
--- a/src/field_attributes.rs
+++ b/src/field_attributes.rs
@@ -758,6 +758,50 @@ where
     T: FromStr + serde::Deserialize<'de>,
     <T as FromStr>::Err: std::fmt::Display,
 {
+    deserialize_vec_from_string_or_vec_on_separator(|c| c == ',')(deserializer)
+}
+
+/// Deserializes a string into a `Vec<T>`. Splitting is defined by `sep`
+///
+/// # Example:
+///
+/// ```rust
+/// use serde_aux::prelude::*;
+/// use std::str::FromStr;
+///
+/// fn dash_or_plus_separated<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+/// where
+///     D: serde::Deserializer<'de>,
+///     T: FromStr + serde::Deserialize<'de>,
+///     <T as FromStr>::Err: std::fmt::Display,
+/// {
+///     deserialize_vec_from_string_or_vec_on_separator(|c| c == '-' || c == '+')(deserializer)
+/// }
+///
+/// #[derive(serde::Serialize, serde::Deserialize, Debug)]
+/// struct MyStruct {
+///     #[serde(deserialize_with = "dash_or_plus_separated")]
+///     list: Vec<i32>,
+/// }
+///
+/// fn main() {
+///     let s = r#" { "list": "1-2+3-4" } "#;
+///     let a: MyStruct = serde_json::from_str(s).unwrap();
+///     assert_eq!(&a.list, &[1, 2, 3, 4]);
+///
+///     let s = r#" { "list": [1,2,3,4] } "#;
+///     let a: MyStruct = serde_json::from_str(s).unwrap();
+///     assert_eq!(&a.list, &[1, 2, 3, 4]);
+/// }
+/// ```
+pub fn deserialize_vec_from_string_or_vec_on_separator<'de, T, D>(
+    sep: impl Fn(char) -> bool,
+) -> impl Fn(D) -> Result<Vec<T>, <D as serde::Deserializer<'de>>::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: FromStr + serde::Deserialize<'de>,
+    <T as FromStr>::Err: std::fmt::Display,
+{
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum StringOrVec<T> {
@@ -765,9 +809,9 @@ where
         Vec(Vec<T>),
     }
 
-    match StringOrVec::<T>::deserialize(deserializer)? {
+    move |deserializer| match StringOrVec::<T>::deserialize(deserializer)? {
         StringOrVec::String(s) => s
-            .split(",")
+            .split(&sep)
             .map(T::from_str)
             .collect::<Result<Vec<_>, _>>()
             .map_err(serde::de::Error::custom),

--- a/src/field_attributes.rs
+++ b/src/field_attributes.rs
@@ -728,3 +728,49 @@ where
         _ => Ok(T::default()),
     }
 }
+
+/// Deserializes a comma separated string into a `Vec<T>`.
+///
+/// # Example:
+///
+/// ```rust
+/// use serde_aux::prelude::*;
+///
+/// #[derive(serde::Serialize, serde::Deserialize, Debug)]
+/// struct MyStruct {
+///     #[serde(deserialize_with = "deserialize_vec_from_string")]
+///     list: Vec<i32>,
+/// }
+///
+/// fn main() {
+///     let s = r#" { "list": "1,2,3,4" } "#;
+///     let a: MyStruct = serde_json::from_str(s).unwrap();
+///     assert_eq!(&a.list, &[1, 2, 3, 4]);
+///
+///     let s = r#" { "list": [1,2,3,4] } "#;
+///     let a: MyStruct = serde_json::from_str(s).unwrap();
+///     assert_eq!(&a.list, &[1, 2, 3, 4]);
+/// }
+/// ```
+pub fn deserialize_vec_from_string<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: FromStr + serde::Deserialize<'de>,
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec<T> {
+        String(String),
+        Vec(Vec<T>),
+    }
+
+    match StringOrVec::<T>::deserialize(deserializer)? {
+        StringOrVec::String(s) => s
+            .split(",")
+            .map(T::from_str)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(serde::de::Error::custom),
+        StringOrVec::Vec(v) => Ok(v),
+    }
+}

--- a/src/field_attributes.rs
+++ b/src/field_attributes.rs
@@ -738,7 +738,7 @@ where
 ///
 /// #[derive(serde::Serialize, serde::Deserialize, Debug)]
 /// struct MyStruct {
-///     #[serde(deserialize_with = "deserialize_vec_from_string")]
+///     #[serde(deserialize_with = "deserialize_vec_from_string_or_vec")]
 ///     list: Vec<i32>,
 /// }
 ///
@@ -752,7 +752,7 @@ where
 ///     assert_eq!(&a.list, &[1, 2, 3, 4]);
 /// }
 /// ```
-pub fn deserialize_vec_from_string<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+pub fn deserialize_vec_from_string_or_vec<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
 where
     D: serde::Deserializer<'de>,
     T: FromStr + serde::Deserialize<'de>,


### PR DESCRIPTION
This function allows to deserialize a comma separated `String` into a `Vec<T>`.

`std::str::pattern::Pattern` is unstable but I was thinking about parameterizing over the split pattern as `&str` or a closure and return a `Fn(D) -> Result<Vec<T>, D::Error>>` but ran into lifetime and type errors...

This is what I tried:

```
pub fn deserialize_vec_from_string_param<'de, T, D>(
    f: impl Fn(char) -> bool,
) -> impl Fn(D) -> Result<Vec<T>, D::Error>
where
    D: serde::Deserializer<'de>,
    T: FromStr + serde::Deserialize<'de>,
    <T as FromStr>::Err: std::fmt::Display,
{
    move |deserializer: D| deserialize_vec_from_string2(f, deserializer)
}

fn deserialize_vec_from_string2<'de, T, D>(
    f: impl Fn(char) -> bool,
    deserializer: D,
) -> Result<Vec<T>, D::Error>
where
    D: serde::Deserializer<'de>,
    T: FromStr + serde::Deserialize<'de>,
    <T as FromStr>::Err: std::fmt::Display,
{
    #[derive(Deserialize)]
    #[serde(untagged)]
    enum StringOrVec<T> {
        String(String),
        Vec(Vec<T>),
    }

    match StringOrVec::<T>::deserialize(deserializer)? {
        StringOrVec::String(s) => s
            .split(f)
            .map(T::from_str)
            .collect::<Result<Vec<_>, _>>()
            .map_err(serde::de::Error::custom),
        StringOrVec::Vec(v) => Ok(v),
    }
}

```

But this does not work...

While [this](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=c903968dbe51b725c545ae02c58427cf) would go in the direction, I intended, it doesn't work as an annotation.