### PR TITLE
Followup: Implement helper to define custom parser

### DIFF
--- a/src/field_attributes.rs
+++ b/src/field_attributes.rs
@@ -861,6 +861,15 @@ impl<'a> From<Vec<Pattern<'a>>> for Pattern<'a> {
     }
 }
 
+impl<'a> std::iter::FromIterator<Pattern<'a>> for Pattern<'a> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Pattern<'a>>,
+    {
+        Pattern::Multiple(iter.into_iter().collect())
+    }
+}
+
 impl<'a, P> From<P> for Pattern<'a>
 where
     P: Fn(char) -> bool + 'static,

--- a/src/field_attributes.rs
+++ b/src/field_attributes.rs
@@ -1090,7 +1090,7 @@ impl<'a, T, E> StringOrVecToVec<'a, T, E> {
             StringOrVec::String(s) => Ok(separator
                 .split(&s)
                 .into_iter()
-                .map(|x| (&mut parser)(x))
+                .map(&mut parser)
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(serde::de::Error::custom)?),
             StringOrVec::Vec(v) => Ok(v),


### PR DESCRIPTION
Following [my last comment](https://github.com/vityafx/serde-aux/pull/15#issuecomment-813361397) in #15, I added another helper to use a custom parser (other than `T::from_str`). While this works as expected, the function names are getting comically long: `deserialize_vec_from_string_or_vec_on_separator_with_parser`. That's almost javaesque. I'm getting `SimpleBeanFactoryMonitorSingletonFactory` flashbacks here :D