### PR TITLE
fix: uncomment the 'chrono' feature flag for a function

### DIFF
--- a/src/field_attributes.rs
+++ b/src/field_attributes.rs
@@ -1,7 +1,9 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use serde::{de::Error, Deserialize, Deserializer};
+#[cfg(feature = "chrono")]
+use serde::de::Error;
+use serde::{Deserialize, Deserializer};
 
 /// Allows a `bool` field to be defaulted to `true`, rather than the normal
 /// default of `false. Useful for fields where the default value should be `true`.

--- a/src/field_attributes.rs
+++ b/src/field_attributes.rs
@@ -50,7 +50,7 @@ pub fn bool_true() -> bool {
 /// assert_eq!(a.time.timestamp(), 1519927261);
 /// assert_eq!(a.time.timestamp_subsec_millis(), 900);
 /// ```
-// #[cfg(feature = "chrono")]
+#[cfg(feature = "chrono")]
 pub fn deserialize_datetime_utc_from_milliseconds<'de, D>(
     deserializer: D,
 ) -> Result<chrono::DateTime<chrono::Utc>, D::Error>


### PR DESCRIPTION
The line `60` has `use chrono::prelude`, but the function doesn't have a cfg feature flag.

https://github.com/vityafx/serde-aux/blob/a5b044e1f8e61292cbdd2cdbbdb490794f5ec982/src/field_attributes.rs#L53-L60

Found the following error message in a library that uses `serde-aux` as a dependency.

```
serde-aux = { version = "4.1.1", default-features = false }
```


<pre><font color="#F66151"><b>error[E0433]</b></font><b>: failed to resolve: use of undeclared crate or module `chrono`</b>
  <font color="#2A7BDE"><b>--&gt; </b></font>/home/hari/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-aux-4.1.1/src/field_attributes.rs:60:9
   <font color="#2A7BDE"><b>|</b></font>
<font color="#2A7BDE"><b>60</b></font> <font color="#2A7BDE"><b>|</b></font>     use chrono::prelude::*;
   <font color="#2A7BDE"><b>| </b></font>        <font color="#F66151"><b>^^^^^^</b></font> <font color="#F66151"><b>use of undeclared crate or module `chrono`</b></font>

<font color="#F66151"><b>error[E0433]</b></font><b>: failed to resolve: use of undeclared crate or module `chrono`</b>
  <font color="#2A7BDE"><b>--&gt; </b></font>/home/hari/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-aux-4.1.1/src/field_attributes.rs:56:13
   <font color="#2A7BDE"><b>|</b></font>
<font color="#2A7BDE"><b>56</b></font> <font color="#2A7BDE"><b>|</b></font> ) -&gt; Result&lt;chrono::DateTime&lt;chrono::Utc&gt;, D::Error&gt;
   <font color="#2A7BDE"><b>| </b></font>            <font color="#F66151"><b>^^^^^^</b></font> <font color="#F66151"><b>use of undeclared crate or module `chrono`</b></font>

<font color="#F66151"><b>error[E0433]</b></font><b>: failed to resolve: use of undeclared crate or module `chrono`</b>
  <font color="#2A7BDE"><b>--&gt; </b></font>/home/hari/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-aux-4.1.1/src/field_attributes.rs:56:30
   <font color="#2A7BDE"><b>|</b></font>
<font color="#2A7BDE"><b>56</b></font> <font color="#2A7BDE"><b>|</b></font> ) -&gt; Result&lt;chrono::DateTime&lt;chrono::Utc&gt;, D::Error&gt;
   <font color="#2A7BDE"><b>| </b></font>                             <font color="#F66151"><b>^^^^^^</b></font> <font color="#F66151"><b>use of undeclared crate or module `chrono`</b></font>

<font color="#F66151"><b>error[E0433]</b></font><b>: failed to resolve: use of undeclared type `DateTime`</b>
  <font color="#2A7BDE"><b>--&gt; </b></font>/home/hari/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-aux-4.1.1/src/field_attributes.rs:67:8
   <font color="#2A7BDE"><b>|</b></font>
<font color="#2A7BDE"><b>67</b></font> <font color="#2A7BDE"><b>|</b></font>     Ok(DateTime::&lt;Utc&gt;::from_utc(
   <font color="#2A7BDE"><b>| </b></font>       <font color="#F66151"><b>^^^^^^^^</b></font> <font color="#F66151"><b>use of undeclared type `DateTime`</b></font>

<font color="#F66151"><b>error[E0433]</b></font><b>: failed to resolve: use of undeclared type `NaiveDateTime`</b>
  <font color="#2A7BDE"><b>--&gt; </b></font>/home/hari/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-aux-4.1.1/src/field_attributes.rs:68:9
   <font color="#2A7BDE"><b>|</b></font>
<font color="#2A7BDE"><b>68</b></font> <font color="#2A7BDE"><b>|</b></font>         NaiveDateTime::from_timestamp_opt(seconds, nanos)
   <font color="#2A7BDE"><b>| </b></font>        <font color="#F66151"><b>^^^^^^^^^^^^^</b></font> <font color="#F66151"><b>use of undeclared type `NaiveDateTime`</b></font>

<font color="#F66151"><b>error[E0412]</b></font><b>: cannot find type `Utc` in this scope</b>
  <font color="#2A7BDE"><b>--&gt; </b></font>/home/hari/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-aux-4.1.1/src/field_attributes.rs:67:19
   <font color="#2A7BDE"><b>|</b></font>
<font color="#2A7BDE"><b>54</b></font> <font color="#2A7BDE"><b>|</b></font> pub fn deserialize_datetime_utc_from_milliseconds&lt;&apos;de, D&gt;(
   <font color="#2A7BDE"><b>| </b></font>                                                        <font color="#2A7BDE"><b>-</b></font> <font color="#2A7BDE"><b>help: you might be missing a type parameter: `, Utc`</b></font>
<font color="#2A7BDE"><b>...</b></font>
<font color="#2A7BDE"><b>67</b></font> <font color="#2A7BDE"><b>|</b></font>     Ok(DateTime::&lt;Utc&gt;::from_utc(
   <font color="#2A7BDE"><b>| </b></font>                  <font color="#F66151"><b>^^^</b></font> <font color="#F66151"><b>not found in this scope</b></font>

<font color="#F66151"><b>error[E0425]</b></font><b>: cannot find value `Utc` in this scope</b>
  <font color="#2A7BDE"><b>--&gt; </b></font>/home/hari/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-aux-4.1.1/src/field_attributes.rs:70:9
   <font color="#2A7BDE"><b>|</b></font>
<font color="#2A7BDE"><b>70</b></font> <font color="#2A7BDE"><b>|</b></font>         Utc,
   <font color="#2A7BDE"><b>| </b></font>        <font color="#F66151"><b>^^^</b></font> <font color="#F66151"><b>not found in this scope</b></font>

</pre>